### PR TITLE
Fixed bug with == override (now replaced with |)

### DIFF
--- a/lib/src/expression.dart
+++ b/lib/src/expression.dart
@@ -50,7 +50,7 @@ abstract class Expression {
   Expression operator -() => UnaryMinus(this);
 
   /// Equal to operator. Returns 1 if true, 0 if false
-  Expression operator ==(Expression exp) => EqualTo(this, exp);
+  Expression operator |(Expression exp) => EqualTo(this, exp);
 
   /// Lower than operator. Returns 1 if true, 0 if false
   Expression operator <(Expression exp) => LowerThan(this, exp);
@@ -590,7 +590,7 @@ class Divide extends BinaryOperator {
   @override
   Expression derive(String toVar) =>
       ((first.derive(toVar) * second) - (first * second.derive(toVar))) /
-      (second * second);
+          (second * second);
 
   /// Possible simplifications:
   ///
@@ -936,7 +936,7 @@ class Vector extends Literal {
   @override
   Expression derive(String toVar) {
     final elementDerivative =
-        elements.map((item) => item.derive(toVar)).toList();
+    elements.map((item) => item.derive(toVar)).toList();
 
     return Vector(elementDerivative);
   }
@@ -1120,9 +1120,9 @@ class IntervalLiteral extends Literal {
   @override
   bool isConstant() =>
       min is Literal &&
-      (min as Literal).isConstant() &&
-      max is Literal &&
-      (max as Literal).isConstant();
+          (min as Literal).isConstant() &&
+          max is Literal &&
+          (max as Literal).isConstant();
 
   @override
   Interval getConstantValue() => Interval(

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -77,9 +77,9 @@ class Parser {
         case TokenType.EQ:
           right = exprStack.removeLast();
           left = exprStack.removeLast();
-          currExpr = left == right;
+          currExpr = left | right;
           break;
-          case TokenType.LTE:
+        case TokenType.LTE:
           right = exprStack.removeLast();
           left = exprStack.removeLast();
           currExpr = left <= right;
@@ -208,7 +208,7 @@ class Lexer {
     keywords['/'] = TokenType.DIV;
     keywords['%'] = TokenType.MOD;
     keywords['^'] = TokenType.POW;
-    keywords['='] = TokenType.EQ;
+    keywords['|'] = TokenType.EQ;
     keywords['<'] = TokenType.LT;
     keywords['≤'] = TokenType.LTE;
     keywords['>'] = TokenType.GT;
@@ -408,7 +408,7 @@ class Lexer {
        * an unary plur or minus, so the tokentype has to be changed.
        */
       if ((curToken.type == TokenType.MINUS ||
-              curToken.type == TokenType.PLUS) &&
+          curToken.type == TokenType.PLUS) &&
           (prevToken == null ||
               prevToken.type.operator ||
               prevToken.type == TokenType.SEPAR ||
@@ -432,8 +432,8 @@ class Lexer {
       if (curToken.type.operator) {
         while (operatorBuffer.isNotEmpty &&
             ((curToken.type.leftAssociative &&
-                    curToken.type.priority <=
-                        operatorBuffer.last.type.priority) ||
+                curToken.type.priority <=
+                    operatorBuffer.last.type.priority) ||
                 (!curToken.type.leftAssociative &&
                     curToken.type.priority <
                         operatorBuffer.last.type.priority))) {
@@ -513,8 +513,8 @@ class Token {
   @override
   bool operator ==(Object token) =>
       (token is Token) &&
-      (token.text == this.text) &&
-      (token.type == this.type);
+          (token.text == this.text) &&
+          (token.type == this.type);
 
   @override
   int get hashCode {
@@ -553,17 +553,17 @@ class TokenType {
   // Operators
   static const TokenType PLUS = TokenType._internal('PLUS', 1, operator: true);
   static const TokenType MINUS =
-      TokenType._internal('MINUS', 1, operator: true);
+  TokenType._internal('MINUS', 1, operator: true);
   static const TokenType TIMES =
-      TokenType._internal('TIMES', 2, operator: true);
+  TokenType._internal('TIMES', 2, operator: true);
   static const TokenType DIV = TokenType._internal('DIV', 2, operator: true);
   static const TokenType MOD = TokenType._internal('MOD', 2, operator: true);
   static const TokenType POW =
-      TokenType._internal('POW', 4, leftAssociative: false, operator: true);
+  TokenType._internal('POW', 4, leftAssociative: false, operator: true);
   static const TokenType UNMINUS =
-      TokenType._internal('UNMINUS', 3, leftAssociative: false, operator: true);
+  TokenType._internal('UNMINUS', 3, leftAssociative: false, operator: true);
   static const TokenType UNPLUS =
-      TokenType._internal('UNPLUS', 3, leftAssociative: false, operator: true);
+  TokenType._internal('UNPLUS', 3, leftAssociative: false, operator: true);
 
   // SGS added token
   static const TokenType EQ =
@@ -579,7 +579,7 @@ class TokenType {
 
   // Functions
   static const TokenType FACTORIAL =
-      TokenType._internal('FACTORIAL', 5, function: true);
+  TokenType._internal('FACTORIAL', 5, function: true);
   static const TokenType SQRT = TokenType._internal('SQRT', 5, function: true);
   static const TokenType ROOT = TokenType._internal('ROOT', 5, function: true);
   static const TokenType LOG = TokenType._internal('LOG', 5, function: true);
@@ -593,10 +593,10 @@ class TokenType {
   static const TokenType ABS = TokenType._internal('ABS', 5, function: true);
   static const TokenType CEIL = TokenType._internal('CEIL', 5, function: true);
   static const TokenType FLOOR =
-      TokenType._internal('FLOOR', 5, function: true);
+  TokenType._internal('FLOOR', 5, function: true);
   static const TokenType SGN = TokenType._internal('SGN', 5, function: true);
   static const TokenType EFUNC =
-      TokenType._internal('EFUNC', 5, function: true);
+  TokenType._internal('EFUNC', 5, function: true);
   static const TokenType FUNC = TokenType._internal('FUNC', 5, function: true);
 
   /// The string value of this token type.
@@ -619,8 +619,8 @@ class TokenType {
   /// provided by this class.
   const TokenType._internal(this.value, this.priority,
       {this.leftAssociative = true,
-      this.operator = false,
-      this.function = false});
+        this.operator = false,
+        this.function = false});
 
   @override
   String toString() => value;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: math_expressions
-version: 2.5.0
+version: 2.5.1
 homepage: https://github.com/fkleon/math-expressions
 description: A library for parsing and evaluating mathematical expressions, supporting real numbers, vectors, and basic interval arithmetic.
 


### PR DESCRIPTION
We needed to have == comparison working. But we cannot override the native ==, so had to chose a different symbol. Which is pipe "|".
